### PR TITLE
ignore timeupdates while seeking

### DIFF
--- a/build/subtitles-octopus/subtitles-octopus.js
+++ b/build/subtitles-octopus/subtitles-octopus.js
@@ -91,6 +91,10 @@ var SubtitlesOctopus = function (options) {
     self.setVideo = function (video) {
         self.video = video;
         if (self.video) {
+            var timeupdate = function () {
+                self.setCurrentTime(video.currentTime + self.timeOffset);
+            }
+            self.video.addEventListener("timeupdate", timeupdate, false);
             self.video.addEventListener("playing", function () {
                 self.setIsPaused(false, video.currentTime + self.timeOffset);
             }, false);
@@ -98,13 +102,14 @@ var SubtitlesOctopus = function (options) {
                 self.setIsPaused(true, video.currentTime + self.timeOffset);
             }, false);
             self.video.addEventListener("seeking", function () {
+                self.video.removeEventListener("timeupdate", timeupdate);
+            }, false);
+            self.video.addEventListener("seeked", function () {
+                self.video.addEventListener("timeupdate", timeupdate, false);
                 self.setCurrentTime(video.currentTime + self.timeOffset);
             }, false);
             self.video.addEventListener("ratechange", function () {
                 self.setRate(video.playbackRate);
-            }, false);
-            self.video.addEventListener("timeupdate", function () {
-                self.setCurrentTime(video.currentTime + self.timeOffset);
             }, false);
 
             document.addEventListener("fullscreenchange", self.resizeWithTimeout, false);

--- a/js/subtitles-octopus.js
+++ b/js/subtitles-octopus.js
@@ -91,6 +91,10 @@ var SubtitlesOctopus = function (options) {
     self.setVideo = function (video) {
         self.video = video;
         if (self.video) {
+            var timeupdate = function () {
+                self.setCurrentTime(video.currentTime + self.timeOffset);
+            }
+            self.video.addEventListener("timeupdate", timeupdate, false);
             self.video.addEventListener("playing", function () {
                 self.setIsPaused(false, video.currentTime + self.timeOffset);
             }, false);
@@ -98,13 +102,14 @@ var SubtitlesOctopus = function (options) {
                 self.setIsPaused(true, video.currentTime + self.timeOffset);
             }, false);
             self.video.addEventListener("seeking", function () {
+                self.video.removeEventListener("timeupdate", timeupdate);
+            }, false);
+            self.video.addEventListener("seeked", function () {
+                self.video.addEventListener("timeupdate", timeupdate, false);
                 self.setCurrentTime(video.currentTime + self.timeOffset);
             }, false);
             self.video.addEventListener("ratechange", function () {
                 self.setRate(video.playbackRate);
-            }, false);
-            self.video.addEventListener("timeupdate", function () {
-                self.setCurrentTime(video.currentTime + self.timeOffset);
             }, false);
 
             document.addEventListener("fullscreenchange", self.resizeWithTimeout, false);


### PR DESCRIPTION
I was working with high bitrate videos that take some time to load. I noticed that when seeking to some position the seeked subtitles appeared instantly while the player (videojs dash in my case) was stopped at the current frame prior seeking. Even worse the subtitles at the seeked position were playing (and would only stop after 5 seconds of not receiving update events iirc).

This fix ignores timeupdates while seeking to keep the videoimage and subtitles consistent.