### PR TITLE
Add conditional to update canvas style on position offset change

### DIFF
--- a/build/subtitles-octopus/subtitles-octopus.js
+++ b/build/subtitles-octopus/subtitles-octopus.js
@@ -337,12 +337,17 @@ var SubtitlesOctopus = function (options) {
         }
     };
 
-    self.resize = function (width, height) {
+    self.resize = function (width, height, top, left) {
         var videoSize = null;
+        top = top || 0;
+        left = left || 0;
         if ((!width || !height) && self.video) {
             videoSize = self.getVideoPosition();
             width = videoSize.width * self.pixelRatio;
             height = videoSize.height * self.pixelRatio;
+            var offset = self.canvasParent.getBoundingClientRect().top - self.video.getBoundingClientRect().top;
+            top = videoSize.y - offset;
+            left = videoSize.x;
         }
         if (!width || !height) {
             if (!self.video) {
@@ -351,7 +356,14 @@ var SubtitlesOctopus = function (options) {
             return;
         }
 
-        if (self.canvas.width != width || self.canvas.height != height) {
+
+
+        if (
+          self.canvas.width != width ||
+          self.canvas.height != height ||
+          self.canvas.style.top != top ||
+          self.canvas.style.left != left
+        ) {
             self.canvas.width = width;
             self.canvas.height = height;
 
@@ -361,9 +373,8 @@ var SubtitlesOctopus = function (options) {
                 self.canvas.style.position = 'absolute';
                 self.canvas.style.width = videoSize.width + 'px';
                 self.canvas.style.height = videoSize.height + 'px';
-                self.canvas.style.left = videoSize.x + 'px';
-                var offset = self.canvasParent.getBoundingClientRect().top - self.video.getBoundingClientRect().top;
-                self.canvas.style.top = (videoSize.y - offset) + 'px';
+                self.canvas.style.top = top + 'px';
+                self.canvas.style.left = left + 'px';
                 self.canvas.style.pointerEvents = 'none';
             }
 

--- a/build/subtitles-octopus/subtitles-octopus.js
+++ b/build/subtitles-octopus/subtitles-octopus.js
@@ -381,7 +381,9 @@ var SubtitlesOctopus = function (options) {
             self.worker.postMessage({
                 target: 'canvas',
                 width: self.canvas.width,
-                height: self.canvas.height
+                height: self.canvas.height,
+                top: top,
+                left: left
             });
         }
     };

--- a/js/subtitles-octopus.js
+++ b/js/subtitles-octopus.js
@@ -337,12 +337,17 @@ var SubtitlesOctopus = function (options) {
         }
     };
 
-    self.resize = function (width, height) {
+    self.resize = function (width, height, top, left) {
         var videoSize = null;
+        top = top || 0;
+        left = left || 0;
         if ((!width || !height) && self.video) {
             videoSize = self.getVideoPosition();
             width = videoSize.width * self.pixelRatio;
             height = videoSize.height * self.pixelRatio;
+            var offset = self.canvasParent.getBoundingClientRect().top - self.video.getBoundingClientRect().top;
+            top = videoSize.y - offset;
+            left = videoSize.x;
         }
         if (!width || !height) {
             if (!self.video) {
@@ -351,7 +356,14 @@ var SubtitlesOctopus = function (options) {
             return;
         }
 
-        if (self.canvas.width != width || self.canvas.height != height) {
+
+
+        if (
+          self.canvas.width != width ||
+          self.canvas.height != height ||
+          self.canvas.style.top != top ||
+          self.canvas.style.left != left
+        ) {
             self.canvas.width = width;
             self.canvas.height = height;
 
@@ -361,9 +373,8 @@ var SubtitlesOctopus = function (options) {
                 self.canvas.style.position = 'absolute';
                 self.canvas.style.width = videoSize.width + 'px';
                 self.canvas.style.height = videoSize.height + 'px';
-                self.canvas.style.left = videoSize.x + 'px';
-                var offset = self.canvasParent.getBoundingClientRect().top - self.video.getBoundingClientRect().top;
-                self.canvas.style.top = (videoSize.y - offset) + 'px';
+                self.canvas.style.top = top + 'px';
+                self.canvas.style.left = left + 'px';
                 self.canvas.style.pointerEvents = 'none';
             }
 

--- a/js/subtitles-octopus.js
+++ b/js/subtitles-octopus.js
@@ -381,7 +381,9 @@ var SubtitlesOctopus = function (options) {
             self.worker.postMessage({
                 target: 'canvas',
                 width: self.canvas.width,
-                height: self.canvas.height
+                height: self.canvas.height,
+                top: top,
+                left: left
             });
         }
     };


### PR DESCRIPTION
The issue was that when the size of the video element grows and the aspect ratio is not maintained, the `top` and `left` positioning offsets of the canvas are not being updated in the `resize` function.

This PR updates the `resize` function to update the `top` and `left` position offsets when a video element is present, and also to accept these offsets as input parameters in the case that just a canvas element is provided instead.