### PR TITLE
Package as node module

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ instance.setCurrentTime(15); // Render subtitles at 00:15 on your canvas
 
 ### Get the Source
 
-Run `git clone --recursive https://github.com/TFSThiagoBR98/JavascriptSubtitlesOctopus.git`
+Run `git clone --recursive https://github.com/Dador/JavascriptSubtitlesOctopus.git`
 
 ### Build
 1) Install Dependencies, see above

--- a/dist/subtitles-octopus.js
+++ b/dist/subtitles-octopus.js
@@ -453,3 +453,9 @@ var SubtitlesOctopus = function (options) {
 if (typeof SubtitlesOctopusOnLoad == 'function') {
     SubtitlesOctopusOnLoad();
 }
+
+if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+        exports = module.exports = SubtitlesOctopus
+    }
+}

--- a/package.json
+++ b/package.json
@@ -1,18 +1,18 @@
 {
-  "name": "libass_wasm",
-  "version": "18.5.0",
+  "name": "libass-wasm",
+  "version": "1.0.0",
   "description": "libass Subtitle Renderer and Parser library for browsers",
-  "main": "dist/wasm/subtitles-octopus.js",
-  "directories": {
-    "example": "example",
-    "lib": "dist/wasm"
-  },
+  "main": "dist/subtitles-octopus.js",
+  "files": [
+    "dist/subtitles*",
+    "example"
+  ],
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/TFSThiagoBR98/JavascriptSubtitlesOctopus.git"
+    "url": "git+https://github.com/Dador/JavascriptSubtitlesOctopus.git"
   },
   "keywords": [
     "libass",
@@ -23,9 +23,9 @@
   "author": "TFSThiagoBR98, Dador",
   "license": "MIT",
   "bugs": {
-    "url": "https://github.com/TFSThiagoBR98/JavascriptSubtitlesOctopus/issues"
+    "url": "https://github.com/Dador/JavascriptSubtitlesOctopus/issues"
   },
-  "homepage": "https://github.com/TFSThiagoBR98/JavascriptSubtitlesOctopus#readme",
+  "homepage": "https://github.com/Dador/JavascriptSubtitlesOctopus#readme",
   "devDependencies": {
     "grunt": "^1.0.3",
     "grunt-exec": "^3.0.0",

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -450,6 +450,14 @@ var SubtitlesOctopus = function (options) {
     self.init();
 };
 
+module.exports = SubtitlesOctopus
+
 if (typeof SubtitlesOctopusOnLoad == 'function') {
     SubtitlesOctopusOnLoad();
+}
+
+if (typeof exports !== 'undefined') {
+    if (typeof module !== 'undefined' && module.exports) {
+        exports = module.exports = SubtitlesOctopus
+    }
 }


### PR DESCRIPTION
Hi @TFSThiagoBR98 I made a few changes to prep for publishing on npmjs. 

I got module exports working and excluded files that won't be needed the library is consumed as a dependency. I'd suggest naming it libass-wasm since that's in line with other wasm packages. We'll want to follow npm's semantic versioning scheme for all future releases, so I figured starting with version 1.0.0 makes sense.

If you're happy with this, I have an account on npmjs already and can publish this.