### PR TITLE
feat(engine): add support for changing subtitles

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -196,7 +196,7 @@ src/subtitles-octopus-worker.bc: dist/libraries/lib/libass.so src/Makefile
 EMCC_COMMON_ARGS = \
 	-s TOTAL_MEMORY=134217728 \
 	-O3 \
-	-s EXPORTED_FUNCTIONS="['_main', '_malloc', '_libassjs_init', '_libassjs_quit', '_libassjs_resize', '_libassjs_render']" \
+	-s EXPORTED_FUNCTIONS="['_main', '_malloc', '_libassjs_init', '_libassjs_quit', '_libassjs_resize', '_libassjs_render', '_libassjs_free_track', '_libassjs_create_track']" \
 	-s EXTRA_EXPORTED_RUNTIME_METHODS="['ccall', 'cwrap', 'getValue', 'FS_createPreloadedFile', 'FS_createFolder']" \
 	-s NO_EXIT_RUNTIME=1 \
 	--use-preload-plugins \

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -1,14 +1,11 @@
 var Module = Module || {};
 
-self.window = self;
-//var self = {};
-
 Module["preRun"] = Module["preRun"] || [];
 
 Module["preRun"].push(function () {
     var i;
 
-    if (self.availableFonts && self.availableFonts.length != 0) {
+    if (self.availableFonts && self.availableFonts.length !== 0) {
         if (!self.subContent) {
             // We can use sync xhr cause we're inside Web Worker
             self.subContent = Module["read"](self.subUrl);
@@ -33,10 +30,10 @@ Module["preRun"].push(function () {
 
     if (self.subContent) {
         Module["FS"].writeFile("/sub.ass", self.subContent);
+    } else {
+        Module["FS"].writeFile("/sub.ass", Module["read"](self.subUrl));
     }
-    else {
-        Module["FS_createPreloadedFile"]("/", "sub.ass", self.subUrl, true, false, null, Module["printErr"]);
-    }
+
     self.subContent = null;
 
     Module["FS_createFolder"]("/", "fonts", true, true);
@@ -48,13 +45,15 @@ Module["preRun"].push(function () {
 });
 
 Module['onRuntimeInitialized'] = function () {
-    self.init = Module['cwrap']('libassjs_init', 'number', ['number', 'number']);
+    self.init = Module['cwrap']('libassjs_init', 'number', ['number', 'number', 'string']);
     self._resize = Module['cwrap']('libassjs_resize', null, ['number', 'number']);
     self._render = Module['cwrap']('libassjs_render', null, ['number', 'number']);
+    self._free_track = Module['cwrap']('libassjs_free_track', null, null);
+    self._create_track = Module['cwrap']('libassjs_create_track', null, ['string']);
     self.quit = Module['cwrap']('libassjs_quit', null, []);
     self.changed = Module._malloc(4);
 
-    self.init(screen.width, screen.height);
+    self.init(screen.width, screen.height, "/sub.ass");
 };
 
 Module["print"] = function (text) {
@@ -89,18 +88,18 @@ if (typeof console === 'undefined') {
 }
 
 // performance.now() polyfill
-if ("performance" in window === false) {
-    window.performance = {};
+if ("performance" in self === false) {
+    self.performance = {};
 }
 Date.now = (Date.now || function () {
     return new Date().getTime();
 });
-if ("now" in window.performance === false) {
+if ("now" in self.performance === false) {
     var nowOffset = Date.now();
     if (performance.timing && performance.timing.navigationStart) {
         nowOffset = performance.timing.navigationStart
     }
-    window.performance.now = function now() {
+    self.performance.now = function now() {
         return Date.now() - nowOffset;
     }
 }

--- a/src/subtitles-octopus-worker.c
+++ b/src/subtitles-octopus-worker.c
@@ -21,9 +21,26 @@ void msg_callback(int level, const char *fmt, va_list va, void *data)
     printf("\n");
 }
 
-void libassjs_init(int frame_w, int frame_h)
+void libassjs_free_track()
 {
-    char *subfile = "sub.ass";
+    if (track)
+    {
+        ass_free_track(track);
+    }
+}
+
+void libassjs_create_track(char *subfile)
+{
+    libassjs_free_track();
+    track = ass_read_file(ass_library, subfile, NULL);
+    if (!track) {
+        printf("track init failed!\n");
+        exit(4);
+    }
+}
+
+void libassjs_init(int frame_w, int frame_h, char *subfile)
+{
     ass_library = ass_library_init();
     if (!ass_library) {
         printf("ass_library_init failed!\n");
@@ -41,11 +58,7 @@ void libassjs_init(int frame_w, int frame_h)
     ass_set_frame_size(ass_renderer, frame_w, frame_h);
     ass_set_fonts(ass_renderer, "default.ttf", NULL, ASS_FONTPROVIDER_FONTCONFIG, "/fonts.conf", 1);
 
-    track = ass_read_file(ass_library, subfile, NULL);
-    if (!track) {
-        printf("track init failed!\n");
-        exit(4);
-    }
+    libassjs_create_track(subfile);
 }
 
 void libassjs_resize(int frame_w, int frame_h)

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -423,6 +423,20 @@ var SubtitlesOctopus = function (options) {
         });
     };
 
+    self.setTrackByUrl = function (url) {
+        self.worker.postMessage({
+            target: 'set-track-by-url',
+            url: url
+        });
+    };
+
+    self.setTrack = function (content) {
+        self.worker.postMessage({
+            target: 'set-track',
+            content: content
+        });
+    };
+
     self.render = self.setCurrentTime;
 
     self.setIsPaused = function (isPaused, currentTime) {
@@ -441,6 +455,10 @@ var SubtitlesOctopus = function (options) {
     };
 
     self.dispose = function () {
+        self.worker.postMessage({
+            target: 'destory'
+        });
+
         self.worker.terminate();
         self.workerActive = false;
         // Remove the canvas element to remove residual subtitles rendered on player


### PR DESCRIPTION
This PR adds support for changing the subtitles without needing to re-initializing the engine. Please note that these changes haven't been applied to the sync version and it might even break it.

This PR also includes these additional changes:
- Refactor the parsing of the ass file for the font names.
- Fix issue with defining `window` in web worker scope causing issue with emscripten boilerplate code (trying to get `document.currentScript`). Not sure whether we want to include this as https://github.com/kripken/emscripten/pull/7231 will also fix the issue.

I'm not exactly sure whether the loading of fonts are working correctly. Any input on that is welcome.

This is not the exact same code as I used for [the version](https://github.com/YePpHa/JavascriptSubtitlesOctopus) I used for my [HTML5 player for Crunchyroll](https://github.com/YePpHa/crunchyroll-html5) as it also includes some "hacky" code to allow for running it in a userscript.