### PR TITLE
Minor cleanups to error handling code

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -40,7 +40,7 @@ var SubtitlesOctopus = function (options) {
     self.workerError = function (error) {
         console.error('Worker error: ', error);
         if (self.onErrorEvent) {
-            self.onErrorEvent();
+            self.onErrorEvent(error);
         }
         if (!self.debug) {
             self.dispose();

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -475,7 +475,9 @@ var SubtitlesOctopus = function (options) {
         self.worker.terminate();
         self.workerActive = false;
         // Remove the canvas element to remove residual subtitles rendered on player
-        self.video.parentNode.removeChild(self.canvasParent);
+        if (self.video) {
+            self.video.parentNode.removeChild(self.canvasParent);
+        }
     };
 
     self.init();


### PR DESCRIPTION
I've made a few minor cleanups that came up while testing various error conditions.

If an error happens while the worker is loading, there is no way to catch the error, so you can't log the error message. I've made it so onError includes the error in its payload.

Also, if you forget to provide the video element, the library will throw an error as it's calling dispose to cleanup from the error. That's just extra noise and we want to avoid that.