### PR TITLE
Missing length function when writing fonts to file system

### DIFF
--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -40,7 +40,7 @@ self.writeAvailableFontsToFS = function(content) {
     var sections = parseAss(content);
 
     for (var i = 0; i < sections.length; i++) {
-        for (var j = 0; j < sections[i].body; j++) {
+        for (var j = 0; j < sections[i].body.length; j++) {
             if (sections[i].body[j].key === 'Style') {
                 self.writeFontToFS(sections[i].body[j].value['Fontname']);
             }


### PR DESCRIPTION
Looks like it was never finding the 'Style' key because the length function was missing from the outer loop.