### PR TITLE
Remove '@' from font name

### DIFF
--- a/dist/subtitles-octopus-worker.js
+++ b/dist/subtitles-octopus-worker.js
@@ -192,7 +192,7 @@ Module["preRun"].push(function() {
   var font;
   var matches;
   while ((matches = regex1.exec(self.subContent)) || (matches = regex2.exec(self.subContent))) {
-   font = matches[1].trim().toLowerCase();
+   font = matches[1].trim().toLowerCase().replace("@", "");
    if (!(font in fontsInSub)) {
     fontsInSub[font] = true;
     if (font in self.availableFonts) {
@@ -5626,7 +5626,7 @@ self.fontMap_ = {};
 self.fontId = 0;
 
 self.writeFontToFS = function(font) {
- font = font.trim().toLowerCase();
+ font = font.trim().toLowerCase().replace("@", "");
  if (self.fontMap_.hasOwnProperty(font)) return;
  self.fontMap_[font] = true;
  if (!self.availableFonts.hasOwnProperty(font)) return;

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -19,7 +19,7 @@ self.fontId = 0;
  * @param {!string} font the font name.
  */
 self.writeFontToFS = function(font) {
-    font = font.trim().toLowerCase();
+    font = font.trim().toLowerCase().replace("@", "");
     if (self.fontMap_.hasOwnProperty(font)) return;
 
     self.fontMap_[font] = true;

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -19,7 +19,7 @@ Module["preRun"].push(function () {
         var font;
         var matches;
         while ((matches = regex1.exec(self.subContent)) || (matches = regex2.exec(self.subContent))) {
-            font = matches[1].trim().toLowerCase();
+            font = matches[1].trim().toLowerCase().replace("@", "");
             if (!(font in fontsInSub)) {
                 fontsInSub[font] = true;
                 if (font in self.availableFonts) {


### PR DESCRIPTION
Some fonts are prefixed with @ at the start of them which makes their entire naming scheme different from the font that need's to be fetched/rendered. This will rename them to the actual font name so it's consistent.