### PR TITLE
Add automatic support for legacy browsers (like Smart TVs)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -311,7 +311,7 @@ EMCC_COMMON_ARGS = \
 	#--memory-init-file 0 \
 	#-s OUTLINING_LIMIT=20000 \
 
-dist: src/subtitles-octopus-worker.bc dist/subtitles-octopus-worker.js dist/subtitles-octopus.js
+dist: src/subtitles-octopus-worker.bc dist/subtitles-octopus-worker.js dist/subtitles-octopus-worker-legacy.js dist/subtitles-octopus.js
 
 dist/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc
 	emcc src/subtitles-octopus-worker.bc $(OCTP_DEPS) \
@@ -319,6 +319,15 @@ dist/subtitles-octopus-worker.js: src/subtitles-octopus-worker.bc
 		--pre-js src/unbrotli.js \
 		--post-js src/post-worker.js \
 		-s WASM=1 \
+		$(EMCC_COMMON_ARGS)
+
+dist/subtitles-octopus-worker-legacy.js: src/subtitles-octopus-worker.bc
+	emcc src/subtitles-octopus-worker.bc $(OCTP_DEPS) \
+		--pre-js src/pre-worker.js \
+		--pre-js src/unbrotli.js \
+		--post-js src/post-worker.js \
+		-s WASM=0 \
+		-s LEGACY_VM_SUPPORT=1 \
 		$(EMCC_COMMON_ARGS)
 
 dist/subtitles-octopus.js:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,8 @@ var options = {
     video: document.getElementById('video'), // HTML5 video element
     subUrl: '/test/test.ass', // Link to subtitles
     fonts: ['/test/font-1.ttf', '/test/font-2.ttf'], // Links to fonts (not required, default font already included in build)
-    workerUrl: '/libassjs-worker.js' // Link to file "libassjs-worker.js"
+    workerUrl: '/libassjs-worker.js', // Link to WebAssembly-based file "libassjs-worker.js"
+    legacyWorkerUrl: '/libassjs-worker-legacy.js' // Link to non-WebAssembly worker
 };
 var instance = new SubtitlesOctopus(options);
 ```

--- a/src/post-worker.js
+++ b/src/post-worker.js
@@ -509,6 +509,11 @@ function onMessageFromMainEmscriptenThread(message) {
             self.fontFiles = message.data.fonts;
             self.fastRenderMode = message.data.fastRender;
             self.availableFonts = message.data.availableFonts;
+            self.debug = message.data.debug;
+            if (!hasNativeConsole && self.debug) {
+                console = makeCustomConsole();
+                console.log("overridden console");
+            }
             if (Module.canvas) {
                 Module.canvas.width_ = message.data.width;
                 Module.canvas.height_ = message.data.height;

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -11,30 +11,32 @@ if (!String.prototype.endsWith) {
 
 // implement console methods if they're missing
 if (typeof console === "undefined") {
-    function postConsoleMessage(prefix, args) {
-        postMessage({
-            target: "console-" + prefix,
-            content: JSON.stringify(Array.prototype.slice.call(args)),
-        })
-    }
-
-    var console = {
-        log: function() {
-            postConsoleMessage("log", arguments);
-        },
-        debug: function() {
-            postConsoleMessage("debug", arguments);
-        },
-        info: function() {
-            postConsoleMessage("info", arguments);
-        },
-        warn: function() {
-            postConsoleMessage("warn", arguments);
-        },
-        error: function() {
-            postConsoleMessage("error", arguments);
+    var console = (function () {
+        function postConsoleMessage(prefix, args) {
+            postMessage({
+                target: "console-" + prefix,
+                content: JSON.stringify(Array.prototype.slice.call(args)),
+            })
         }
-    };
+
+        return {
+            log: function() {
+                postConsoleMessage("log", arguments);
+            },
+            debug: function() {
+                postConsoleMessage("debug", arguments);
+            },
+            info: function() {
+                postConsoleMessage("info", arguments);
+            },
+            warn: function() {
+                postConsoleMessage("warn", arguments);
+            },
+            error: function() {
+                postConsoleMessage("error", arguments);
+            }
+        }
+    })();
 }
 
 Module = Module || {};

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -1,4 +1,14 @@
 //var Module = Module || {};
+
+if (!String.prototype.endsWith) {
+	String.prototype.endsWith = function(search, this_len) {
+		if (this_len === undefined || this_len > this.length) {
+			this_len = this.length;
+		}
+		return this.substring(this_len - search.length, this_len) === search;
+	};
+}
+
 Module = Module || {};
 
 Module["preRun"] = Module["preRun"] || [];

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -9,6 +9,34 @@ if (!String.prototype.endsWith) {
 	};
 }
 
+// implement console methods if they're missing
+if (typeof console === "undefined") {
+    function postConsoleMessage(prefix, args) {
+        postMessage({
+            target: "console-" + prefix,
+            content: JSON.stringify(Array.prototype.slice.call(args)),
+        })
+    }
+
+    var console = {
+        log: function() {
+            postConsoleMessage("log", arguments);
+        },
+        debug: function() {
+            postConsoleMessage("debug", arguments);
+        },
+        info: function() {
+            postConsoleMessage("info", arguments);
+        },
+        warn: function() {
+            postConsoleMessage("warn", arguments);
+        },
+        error: function() {
+            postConsoleMessage("error", arguments);
+        }
+    };
+}
+
 Module = Module || {};
 
 Module["preRun"] = Module["preRun"] || [];

--- a/src/pre-worker.js
+++ b/src/pre-worker.js
@@ -9,8 +9,10 @@ if (!String.prototype.endsWith) {
 	};
 }
 
+var hasNativeConsole = typeof console !== "undefined";
+
 // implement console methods if they're missing
-if (typeof console === "undefined") {
+function makeCustomConsole() {
     var console = (function () {
         function postConsoleMessage(prefix, args) {
             postMessage({
@@ -37,6 +39,8 @@ if (typeof console === "undefined") {
             }
         }
     })();
+
+    return console;
 }
 
 Module = Module || {};
@@ -109,7 +113,7 @@ Module["printErr"] = function (text) {
 };
 
 // Modified from https://github.com/kripken/emscripten/blob/6dc4ac5f9e4d8484e273e4dcc554f809738cedd6/src/proxyWorker.js
-if (typeof console === 'undefined') {
+if (!hasNativeConsole) {
     // we can't call Module.printErr because that might be circular
     var console = {
         log: function (x) {

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -103,7 +103,8 @@ var SubtitlesOctopus = function (options) {
             subUrl: self.subUrl,
             subContent: self.subContent,
             fonts: self.fonts,
-            availableFonts: self.availableFonts
+            availableFonts: self.availableFonts,
+            debug: self.debug
         });
     };
 

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -1,4 +1,16 @@
 var SubtitlesOctopus = function (options) {
+    var supportsWebAssembly = false;
+    try {
+        if (typeof WebAssembly === "object"
+            && typeof WebAssembly.instantiate === "function") {
+            const module = new WebAssembly.Module(Uint8Array.of(0x0, 0x61, 0x73, 0x6d, 0x01, 0x00, 0x00, 0x00));
+            if (module instanceof WebAssembly.Module)
+                supportsWebAssembly = (new WebAssembly.Instance(module) instanceof WebAssembly.Instance);
+        }
+    } catch (e) {
+    }
+    console.log("WebAssembly support detected: " + (supportsWebAssembly ? "yes" : "no"));
+
     var self = this;
     self.canvas = options.canvas; // HTML canvas element (optional if video specified)
     self.lossyRender = options.lossyRender; // Speedup render for heavy subs
@@ -8,7 +20,11 @@ var SubtitlesOctopus = function (options) {
     self.fonts = options.fonts || []; // Array with links to fonts used in sub (optional)
     self.availableFonts = options.availableFonts || []; // Object with all available fonts (optional). Key is font name in lower case, value is link: {"arial": "/font1.ttf"}
     self.onReadyEvent = options.onReady; // Function called when SubtitlesOctopus is ready (optional)
-    self.workerUrl = options.workerUrl || 'libassjs-worker.js'; // Link to worker
+    if (supportsWebAssembly) {
+        self.workerUrl = options.workerUrl || 'subtitles-octopus-worker.js'; // Link to WebAssembly worker
+    } else {
+        self.workerUrl = options.legacyWorkerUrl || 'subtitles-octopus-worker-legacy.js'; // Link to legacy worker
+    }
     self.subUrl = options.subUrl; // Link to sub file (optional if subContent specified)
     self.subContent = options.subContent || null; // Sub content (optional if subUrl specified)
     self.onErrorEvent = options.onError; // Function called in case of critical error meaning sub wouldn't be shown and you should use alternative method (for instance it occurs if browser doesn't support web workers).

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -252,6 +252,26 @@ var SubtitlesOctopus = function (options) {
                 console.log(data.content);
                 break;
             }
+            case 'console-log': {
+                console.log.apply(console, JSON.parse(data.content));
+                break;
+            }
+            case 'console-debug': {
+                console.debug.apply(console, JSON.parse(data.content));
+                break;
+            }
+            case 'console-info': {
+                console.info.apply(console, JSON.parse(data.content));
+                break;
+            }
+            case 'console-warn': {
+                console.warn.apply(console, JSON.parse(data.content));
+                break;
+            }
+            case 'console-error': {
+                console.error.apply(console, JSON.parse(data.content));
+                break;
+            }
             case 'stderr': {
                 console.error(data.content);
                 break;

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -18,25 +18,34 @@ var SubtitlesOctopus = function (options) {
 
     self.timeOffset = options.timeOffset || 0; // Time offset would be applied to currentTime from video (option)
 
-    if (typeof ImageData.prototype.constructor !== 'function') {
-        (function () {
-            var canvas = document.createElement('canvas');
-            var ctx = canvas.getContext('2d');
-
-            window.ImageData = function () {
-                var i = 0;
-                if (arguments[0] instanceof Uint8ClampedArray) {
-                    var data = arguments[i++];
-                }
-                var width = arguments[i++];
-                var height = arguments[i];
-
-                var imageData = ctx.createImageData(width, height);
-                if (data) imageData.data.set(data);
-                return imageData;
+    (function() {
+        if (typeof ImageData.prototype.constructor === 'function') {
+            try {
+                // try actually calling ImageData, as on some browsers it's reported
+                // as existing but calling it errors out as "TypeError: Illegal constructor"
+                new window.ImageData(new Uint8ClampedArray([0, 0, 0, 0]), 1, 1);
+                return;
+            } catch (e) {
+                console.log("detected that ImageData is not constructable despite browser saying so");
             }
-        })();
-    }
+        }
+
+        var canvas = document.createElement('canvas');
+        var ctx = canvas.getContext('2d');
+
+        window.ImageData = function () {
+            var i = 0;
+            if (arguments[0] instanceof Uint8ClampedArray) {
+                var data = arguments[i++];
+            }
+            var width = arguments[i++];
+            var height = arguments[i];
+
+            var imageData = ctx.createImageData(width, height);
+            if (data) imageData.data.set(data);
+            return imageData;
+        }
+    })();
 
     self.workerError = function (error) {
         console.error('Worker error: ', error);


### PR DESCRIPTION
* Change `Makefile` to produce both WebAssembly and legacy JS versions at the same time
* Add `legacyWorkerUrl` parameter to `SubtitlesOctopus()`
* Make `SubtitlesOctopus()` choose WebAssembly or legacy worker based on whether WebAssembly is supported by current browser
* Improve detection of `ImageData()` constructor (faced a case where browser lied about it being supported)
* Added a polyfill for `String.endsWith()`
* Added custom overrides for `console.log()` and friends so logging from web worker works even if the browser doesn't support it directly

All this allows me to successfully play a video with subtitles on the built-in WebOS browser starting from WebOS 1.2.x family (tested in WebOS 1.2 and WebOS 2.0 via emulators).