### PR TITLE
Initial resize fires too soon

### DIFF
--- a/dist/js/subtitles-octopus.js
+++ b/dist/js/subtitles-octopus.js
@@ -164,6 +164,7 @@ var SubtitlesOctopus = function (options) {
             self.video.addEventListener("timeupdate", timeupdate, false);
             self.video.addEventListener("playing", function () {
                 self.setIsPaused(false, video.currentTime + self.timeOffset);
+                self.resizeWithTimeout();
             }, false);
             self.video.addEventListener("pause", function () {
                 self.setIsPaused(true, video.currentTime + self.timeOffset);


### PR DESCRIPTION
Running on Web0S, that runs on a dinosaur of Chrome (ver 53.0.2785.34), on TV with no manual resize available

"loadedmetadata" fires too soon, leaving the canvas in initial display:none state.

"playing" seems like a safe place to resize