### PR TITLE
Initial resize fire too soon

### DIFF
--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -170,6 +170,7 @@ var SubtitlesOctopus = function (options) {
             self.video.addEventListener("timeupdate", timeupdate, false);
             self.video.addEventListener("playing", function () {
                 self.setIsPaused(false, video.currentTime + self.timeOffset);
+                self.resizeWithTimeout();
             }, false);
             self.video.addEventListener("pause", function () {
                 self.setIsPaused(true, video.currentTime + self.timeOffset);


### PR DESCRIPTION
Running on Web0S, that runs on an old chrome/webkit engine 53.0.2785.34. On TV, with no manual window resizing available.

The "loadedmetadata" event fires too soon, leaving canvas in initial display:none state.

"playing" seems like a safe place for initial resize