### PR TITLE
VEX-4338: Default Font Override, Ready Event, WASM file fetch failure catch

### DIFF
--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -159,11 +159,6 @@ Module.expectedDataFileDownloads++;
  };
  loadPackage({
   "files": [ {
-   "start": 0,
-   "audio": 0,
-   "end": 145972,
-   "filename": "/assets/default.woff2"
-  }, {
    "start": 145972,
    "audio": 0,
    "end": 146775,
@@ -251,6 +246,8 @@ Module["preRun"].push(function() {
  for (i = 0; i < fontFiles.length; i++) {
   Module["FS_createPreloadedFile"]("/fonts", "font" + i + "-" + fontFiles[i].split("/").pop(), fontFiles[i], true, true);
  }
+ console.warn(`nicktest; defualt.woff2 download start; ${self.defaultFont}`)
+ Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
 });
 
 Module["onRuntimeInitialized"] = function() {
@@ -2437,6 +2434,10 @@ function createWasm() {
      err("falling back to ArrayBuffer instantiation");
      instantiateArrayBuffer(receiveInstantiatedSource);
     });
+   }).catch(function(error) {
+     err("Could not download wasm file");
+     err("falling back to ArrayBuffer instantiation");
+     return instantiateArrayBuffer(receiveInstantiatedSource);
    });
   } else {
    return instantiateArrayBuffer(receiveInstantiatedSource);
@@ -10036,6 +10037,7 @@ function onMessageFromMainEmscriptenThread(message) {
    self.subUrl = message.data.subUrl;
    self.subContent = message.data.subContent;
    self.fontFiles = message.data.fonts;
+   self.defaultFont = message.data.defaultFont;
    self.fastRenderMode = message.data.fastRender;
    self.availableFonts = message.data.availableFonts;
    self.debug = message.data.debug;
@@ -10051,6 +10053,9 @@ function onMessageFromMainEmscriptenThread(message) {
     }
    }
    removeRunDependency("worker-init");
+   postMessage({
+    target: "ready",
+   });
    break;
   }
 

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -246,7 +246,6 @@ Module["preRun"].push(function() {
  for (i = 0; i < fontFiles.length; i++) {
   Module["FS_createPreloadedFile"]("/fonts", "font" + i + "-" + fontFiles[i].split("/").pop(), fontFiles[i], true, true);
  }
- console.warn(`nicktest; cr; defualt.woff2 download start; ${self.defaultFont}`)
  Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
 });
 

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -136,6 +136,7 @@ Module.expectedDataFileDownloads++;
     for (var i = 0; i < files.length; ++i) {
      DataRequest.prototype.requests[files[i].filename].onload();
     }
+    Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
     Module["removeRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
    }
    Module["addRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
@@ -246,7 +247,6 @@ Module["preRun"].push(function() {
  for (i = 0; i < fontFiles.length; i++) {
   Module["FS_createPreloadedFile"]("/fonts", "font" + i + "-" + fontFiles[i].split("/").pop(), fontFiles[i], true, true);
  }
- Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
 });
 
 Module["onRuntimeInitialized"] = function() {

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -166,14 +166,14 @@ Module.expectedDataFileDownloads++;
     "end": 146775,
     "filename": "/assets/fonts.conf"
   }];
-//  if (!self.defaultFont) {
-//    filesToLoad.shift({
-//      "start": 0,
-//      "audio": 0,
-//      "end": 145972,
-//      "filename": "/assets/default.woff2"
-//    });
-//  }
+ if (!self.defaultFont) {
+   filesToLoad.unshift({
+     "start": 0,
+     "audio": 0,
+     "end": 145972,
+     "filename": "/assets/default.woff2"
+   });
+ }
  loadPackage({
   "files": filesToLoad,
   "remote_package_size": 146775,

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -123,6 +123,12 @@ Module.expectedDataFileDownloads++;
     }
    };
    var files = metadata["files"];
+   console.warn(`nicktest; worker; later; ${self.defaultFont}`);
+    if (self.defaultFont) {
+      // remove the default.woff2 file from list since we will overwrite
+      files.shift();
+      Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
+    }
    for (var i = 0; i < files.length; ++i) {
     new DataRequest(files[i]["start"], files[i]["end"], files[i]["audio"]).open("GET", files[i]["filename"]);
    }
@@ -132,12 +138,8 @@ Module.expectedDataFileDownloads++;
     assert(arrayBuffer instanceof ArrayBuffer, "bad input to processPackageData");
     var byteArray = new Uint8Array(arrayBuffer);
     DataRequest.prototype.byteArray = byteArray;
-    var files = metadata["files"];
     for (var i = 0; i < files.length; ++i) {
      DataRequest.prototype.requests[files[i].filename].onload();
-    }
-    if (self.defaultFont) {
-      Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
     }
     Module["removeRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
    }
@@ -160,23 +162,18 @@ Module.expectedDataFileDownloads++;
    Module["preRun"].push(runWithFS);
   }
  };
- var filesToLoad = [{
-    "start": 145972,
-    "audio": 0,
-    "end": 146775,
-    "filename": "/assets/fonts.conf"
-  }];
-  console.warn(`nicktest; worker; ${self.defaultFont}`)
- if (!self.defaultFont) {
-   filesToLoad.unshift({
-     "start": 0,
-     "audio": 0,
-     "end": 145972,
-     "filename": "/assets/default.woff2"
-   });
- }
  loadPackage({
-  "files": filesToLoad,
+  "files": [ {
+   "start": 0,
+   "audio": 0,
+   "end": 145972,
+   "filename": "/assets/default.woff2"
+  }, {
+   "start": 145972,
+   "audio": 0,
+   "end": 146775,
+   "filename": "/assets/fonts.conf"
+  } ],
   "remote_package_size": 146775,
   "package_uuid": "43f55d8e-e644-4070-b252-e03ac41196bc"
  });

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -136,7 +136,9 @@ Module.expectedDataFileDownloads++;
     for (var i = 0; i < files.length; ++i) {
      DataRequest.prototype.requests[files[i].filename].onload();
     }
-    Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
+    if (self.defaultFont) {
+      Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
+    }
     Module["removeRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
    }
    Module["addRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
@@ -160,6 +162,11 @@ Module.expectedDataFileDownloads++;
  };
  loadPackage({
   "files": [ {
+   "start": 0,
+   "audio": 0,
+   "end": 145972,
+   "filename": "/assets/default.woff2"
+  }, {
    "start": 145972,
    "audio": 0,
    "end": 146775,

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -126,7 +126,7 @@ Module.expectedDataFileDownloads++;
    if (self.defaultFont) {
     // remove the default.woff2 file from list since we will overwrite
     files.shift();
-    Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
+    Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true, () => {}, () => {});
    }
    for (var i = 0; i < files.length; ++i) {
     new DataRequest(files[i]["start"], files[i]["end"], files[i]["audio"]).open("GET", files[i]["filename"]);

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -2435,7 +2435,7 @@ function createWasm() {
      instantiateArrayBuffer(receiveInstantiatedSource);
     });
    }).catch(function(error) {
-     err("Could not download wasm file");
+     err("Could not download wasm file: " + error);
      err("falling back to ArrayBuffer instantiation");
      return instantiateArrayBuffer(receiveInstantiatedSource);
    });

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -160,18 +160,22 @@ Module.expectedDataFileDownloads++;
    Module["preRun"].push(runWithFS);
   }
  };
+ var filesToLoad = [{
+    "start": 145972,
+    "audio": 0,
+    "end": 146775,
+    "filename": "/assets/fonts.conf"
+  }];
+ if (!self.defaultFont) {
+   filesToLoad.shift({
+     "start": 0,
+     "audio": 0,
+     "end": 145972,
+     "filename": "/assets/default.woff2"
+   });
+ }
  loadPackage({
-  "files": [ {
-   "start": 0,
-   "audio": 0,
-   "end": 145972,
-   "filename": "/assets/default.woff2"
-  }, {
-   "start": 145972,
-   "audio": 0,
-   "end": 146775,
-   "filename": "/assets/fonts.conf"
-  } ],
+  "files": filesToLoad,
   "remote_package_size": 146775,
   "package_uuid": "43f55d8e-e644-4070-b252-e03ac41196bc"
  });

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -246,8 +246,8 @@ Module["preRun"].push(function() {
  for (i = 0; i < fontFiles.length; i++) {
   Module["FS_createPreloadedFile"]("/fonts", "font" + i + "-" + fontFiles[i].split("/").pop(), fontFiles[i], true, true);
  }
- console.warn(`nicktest; defualt.woff2 download start; ${self.defaultFont}`)
- Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
+//  console.warn(`nicktest; cr; defualt.woff2 download start; ${self.defaultFont}`)
+//  Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
 });
 
 Module["onRuntimeInitialized"] = function() {

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -136,9 +136,9 @@ Module.expectedDataFileDownloads++;
     for (var i = 0; i < files.length; ++i) {
      DataRequest.prototype.requests[files[i].filename].onload();
     }
-    // if (self.defaultFont) {
+    if (self.defaultFont) {
       Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
-    // }
+    }
     Module["removeRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
    }
    Module["addRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -123,12 +123,11 @@ Module.expectedDataFileDownloads++;
     }
    };
    var files = metadata["files"];
-   console.warn(`nicktest; worker; later; ${self.defaultFont}`);
-    if (self.defaultFont) {
-      // remove the default.woff2 file from list since we will overwrite
-      files.shift();
-      Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
-    }
+   if (self.defaultFont) {
+    // remove the default.woff2 file from list since we will overwrite
+    files.shift();
+    Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
+   }
    for (var i = 0; i < files.length; ++i) {
     new DataRequest(files[i]["start"], files[i]["end"], files[i]["audio"]).open("GET", files[i]["filename"]);
    }

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -166,6 +166,7 @@ Module.expectedDataFileDownloads++;
     "end": 146775,
     "filename": "/assets/fonts.conf"
   }];
+  console.warn(`nicktest; worker; ${self.defaultFont}`)
  if (!self.defaultFont) {
    filesToLoad.unshift({
      "start": 0,

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -246,8 +246,8 @@ Module["preRun"].push(function() {
  for (i = 0; i < fontFiles.length; i++) {
   Module["FS_createPreloadedFile"]("/fonts", "font" + i + "-" + fontFiles[i].split("/").pop(), fontFiles[i], true, true);
  }
-//  console.warn(`nicktest; cr; defualt.woff2 download start; ${self.defaultFont}`)
-//  Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
+ console.warn(`nicktest; cr; defualt.woff2 download start; ${self.defaultFont}`)
+ Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
 });
 
 Module["onRuntimeInitialized"] = function() {

--- a/dist/js/subtitles-octopus-worker.js
+++ b/dist/js/subtitles-octopus-worker.js
@@ -136,9 +136,9 @@ Module.expectedDataFileDownloads++;
     for (var i = 0; i < files.length; ++i) {
      DataRequest.prototype.requests[files[i].filename].onload();
     }
-    if (self.defaultFont) {
+    // if (self.defaultFont) {
       Module["FS_createPreloadedFile"]("/assets/default.woff2", null, self.defaultFont, true, true);
-    }
+    // }
     Module["removeRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
    }
    Module["addRunDependency"]("datafile_dist/js/subtitles-octopus-worker.data");
@@ -166,14 +166,14 @@ Module.expectedDataFileDownloads++;
     "end": 146775,
     "filename": "/assets/fonts.conf"
   }];
- if (!self.defaultFont) {
-   filesToLoad.shift({
-     "start": 0,
-     "audio": 0,
-     "end": 145972,
-     "filename": "/assets/default.woff2"
-   });
- }
+//  if (!self.defaultFont) {
+//    filesToLoad.shift({
+//      "start": 0,
+//      "audio": 0,
+//      "end": 145972,
+//      "filename": "/assets/default.woff2"
+//    });
+//  }
  loadPackage({
   "files": filesToLoad,
   "remote_package_size": 146775,

--- a/dist/js/subtitles-octopus.js
+++ b/dist/js/subtitles-octopus.js
@@ -37,7 +37,7 @@ var SubtitlesOctopus = function (options) {
 
     self.hasAlphaBug = false;
 
-    (function () {
+    (function() {
         if (typeof ImageData.prototype.constructor === 'function') {
             try {
                 // try actually calling ImageData, as on some browsers it's reported
@@ -63,7 +63,7 @@ var SubtitlesOctopus = function (options) {
             var imageData = ctx.createImageData(width, height);
             if (data) imageData.data.set(data);
             return imageData;
-        };
+        }
     })();
 
     self.workerError = function (error) {
@@ -162,7 +162,7 @@ var SubtitlesOctopus = function (options) {
         if (self.video) {
             var timeupdate = function () {
                 self.setCurrentTime(video.currentTime + self.timeOffset);
-            };
+            }
             self.video.addEventListener("timeupdate", timeupdate, false);
             self.video.addEventListener("playing", function () {
                 self.setIsPaused(false, video.currentTime + self.timeOffset);
@@ -419,10 +419,10 @@ var SubtitlesOctopus = function (options) {
 
 
         if (
-            self.canvas.width != width ||
-            self.canvas.height != height ||
-            self.canvas.style.top != top ||
-            self.canvas.style.left != left
+          self.canvas.width != width ||
+          self.canvas.height != height ||
+          self.canvas.style.top != top ||
+          self.canvas.style.left != left
         ) {
             self.canvas.width = width;
             self.canvas.height = height;
@@ -589,6 +589,6 @@ if (typeof SubtitlesOctopusOnLoad == 'function') {
 
 if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports) {
-        exports = module.exports = SubtitlesOctopus;
+        exports = module.exports = SubtitlesOctopus
     }
 }

--- a/dist/js/subtitles-octopus.js
+++ b/dist/js/subtitles-octopus.js
@@ -19,6 +19,7 @@ var SubtitlesOctopus = function (options) {
     self.canvasParent = null; // (internal) HTML canvas parent element
     self.fonts = options.fonts || []; // Array with links to fonts used in sub (optional)
     self.availableFonts = options.availableFonts || []; // Object with all available fonts (optional). Key is font name in lower case, value is link: {"arial": "/font1.ttf"}
+    console.warn(`nicktest; vso; SubtitlesOctopus; ${options.defaultFont}`);
     self.defaultFont = options.defaultFont;
     self.onReadyEvent = options.onReady; // Function called when SubtitlesOctopus is ready (optional)
     if (supportsWebAssembly) {
@@ -93,6 +94,7 @@ var SubtitlesOctopus = function (options) {
         self.createCanvas();
         self.setVideo(options.video);
         self.setSubUrl(options.subUrl);
+        console.warn(`nicktest; vso; init; ${self.defaultFont}`);
         self.worker.postMessage({
             target: 'worker-init',
             width: self.canvas.width,

--- a/dist/js/subtitles-octopus.js
+++ b/dist/js/subtitles-octopus.js
@@ -19,6 +19,7 @@ var SubtitlesOctopus = function (options) {
     self.canvasParent = null; // (internal) HTML canvas parent element
     self.fonts = options.fonts || []; // Array with links to fonts used in sub (optional)
     self.availableFonts = options.availableFonts || []; // Object with all available fonts (optional). Key is font name in lower case, value is link: {"arial": "/font1.ttf"}
+    self.defaultFont = options.defaultFont;
     self.onReadyEvent = options.onReady; // Function called when SubtitlesOctopus is ready (optional)
     if (supportsWebAssembly) {
         self.workerUrl = options.workerUrl || 'subtitles-octopus-worker.js'; // Link to WebAssembly worker
@@ -36,7 +37,7 @@ var SubtitlesOctopus = function (options) {
 
     self.hasAlphaBug = false;
 
-    (function() {
+    (function () {
         if (typeof ImageData.prototype.constructor === 'function') {
             try {
                 // try actually calling ImageData, as on some browsers it's reported
@@ -62,7 +63,7 @@ var SubtitlesOctopus = function (options) {
             var imageData = ctx.createImageData(width, height);
             if (data) imageData.data.set(data);
             return imageData;
-        }
+        };
     })();
 
     self.workerError = function (error) {
@@ -161,7 +162,7 @@ var SubtitlesOctopus = function (options) {
         if (self.video) {
             var timeupdate = function () {
                 self.setCurrentTime(video.currentTime + self.timeOffset);
-            }
+            };
             self.video.addEventListener("timeupdate", timeupdate, false);
             self.video.addEventListener("playing", function () {
                 self.setIsPaused(false, video.currentTime + self.timeOffset);
@@ -418,10 +419,10 @@ var SubtitlesOctopus = function (options) {
 
 
         if (
-          self.canvas.width != width ||
-          self.canvas.height != height ||
-          self.canvas.style.top != top ||
-          self.canvas.style.left != left
+            self.canvas.width != width ||
+            self.canvas.height != height ||
+            self.canvas.style.top != top ||
+            self.canvas.style.left != left
         ) {
             self.canvas.width = width;
             self.canvas.height = height;
@@ -588,6 +589,6 @@ if (typeof SubtitlesOctopusOnLoad == 'function') {
 
 if (typeof exports !== 'undefined') {
     if (typeof module !== 'undefined' && module.exports) {
-        exports = module.exports = SubtitlesOctopus
+        exports = module.exports = SubtitlesOctopus;
     }
 }

--- a/dist/js/subtitles-octopus.js
+++ b/dist/js/subtitles-octopus.js
@@ -19,7 +19,6 @@ var SubtitlesOctopus = function (options) {
     self.canvasParent = null; // (internal) HTML canvas parent element
     self.fonts = options.fonts || []; // Array with links to fonts used in sub (optional)
     self.availableFonts = options.availableFonts || []; // Object with all available fonts (optional). Key is font name in lower case, value is link: {"arial": "/font1.ttf"}
-    console.warn(`nicktest; vso; SubtitlesOctopus; ${options.defaultFont}`);
     self.defaultFont = options.defaultFont;
     self.onReadyEvent = options.onReady; // Function called when SubtitlesOctopus is ready (optional)
     if (supportsWebAssembly) {
@@ -94,7 +93,6 @@ var SubtitlesOctopus = function (options) {
         self.createCanvas();
         self.setVideo(options.video);
         self.setSubUrl(options.subUrl);
-        console.warn(`nicktest; vso; init; ${self.defaultFont}`);
         self.worker.postMessage({
             target: 'worker-init',
             width: self.canvas.width,

--- a/dist/js/subtitles-octopus.js
+++ b/dist/js/subtitles-octopus.js
@@ -104,6 +104,7 @@ var SubtitlesOctopus = function (options) {
             subContent: self.subContent,
             fonts: self.fonts,
             availableFonts: self.availableFonts,
+            defaultFont: self.defaultFont,
             debug: self.debug
         });
     };
@@ -386,6 +387,9 @@ var SubtitlesOctopus = function (options) {
             case 'get-styles': {
                 console.log(data.target);
                 console.log(data.styles);
+                break;
+            }
+            case 'ready': {
                 break;
             }
             default:

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -22,6 +22,8 @@ var SubtitlesOctopus = function (options) {
     self.canvasParent = null; // (internal) HTML canvas parent element
     self.fonts = options.fonts || []; // Array with links to fonts used in sub (optional)
     self.availableFonts = options.availableFonts || []; // Object with all available fonts (optional). Key is font name in lower case, value is link: {"arial": "/font1.ttf"}
+    console.warn(`nicktest; vso; SubtitlesOctopus; other; ${options.defaultFont}`);
+    self.defaultFont = options.defaultFont;
     self.onReadyEvent = options.onReady; // Function called when SubtitlesOctopus is ready (optional)
     if (supportsWebAssembly) {
         self.workerUrl = options.workerUrl || 'subtitles-octopus-worker.js'; // Link to WebAssembly worker
@@ -95,6 +97,7 @@ var SubtitlesOctopus = function (options) {
         self.createCanvas();
         self.setVideo(options.video);
         self.setSubUrl(options.subUrl);
+        console.warn(`nicktest; vso; init; Other; ${self.defaultFont}`);
         self.worker.postMessage({
             target: 'worker-init',
             width: self.canvas.width,
@@ -107,6 +110,7 @@ var SubtitlesOctopus = function (options) {
             subContent: self.subContent,
             fonts: self.fonts,
             availableFonts: self.availableFonts,
+            defaultFont: self.defaultFont,
             debug: self.debug,
             targetFps: self.targetFps,
             libassMemoryLimit: self.libassMemoryLimit,

--- a/src/subtitles-octopus.js
+++ b/src/subtitles-octopus.js
@@ -22,8 +22,6 @@ var SubtitlesOctopus = function (options) {
     self.canvasParent = null; // (internal) HTML canvas parent element
     self.fonts = options.fonts || []; // Array with links to fonts used in sub (optional)
     self.availableFonts = options.availableFonts || []; // Object with all available fonts (optional). Key is font name in lower case, value is link: {"arial": "/font1.ttf"}
-    console.warn(`nicktest; vso; SubtitlesOctopus; other; ${options.defaultFont}`);
-    self.defaultFont = options.defaultFont;
     self.onReadyEvent = options.onReady; // Function called when SubtitlesOctopus is ready (optional)
     if (supportsWebAssembly) {
         self.workerUrl = options.workerUrl || 'subtitles-octopus-worker.js'; // Link to WebAssembly worker
@@ -97,7 +95,6 @@ var SubtitlesOctopus = function (options) {
         self.createCanvas();
         self.setVideo(options.video);
         self.setSubUrl(options.subUrl);
-        console.warn(`nicktest; vso; init; Other; ${self.defaultFont}`);
         self.worker.postMessage({
             target: 'worker-init',
             width: self.canvas.width,
@@ -110,7 +107,6 @@ var SubtitlesOctopus = function (options) {
             subContent: self.subContent,
             fonts: self.fonts,
             availableFonts: self.availableFonts,
-            defaultFont: self.defaultFont,
             debug: self.debug,
             targetFps: self.targetFps,
             libassMemoryLimit: self.libassMemoryLimit,


### PR DESCRIPTION
Adds override for font file, ready event, catch for wasm file fetch failure

Jira: VEX-4338
https://jira.tenkasu.net/browse/VEX-4338

- Changes were made to the static output files, as updates to the source files were not possible due to inability to run emscripten compiler with provided docker or on local machine
- Migrates existing changes made directly in velocity static files to add a ready event on init, and catching errors for failure to fetch wasm file
- Adds default font override, to allow clients to add any font of their choosing as the default font (in case characters are not found, eg. arabic)

### Major/minor reviewer
- Major reviewer (domain expert): @armadilio3
- Minor reviewer: @gkielyellation

### Testing instructions

Test URL:
document.cookie="VILOS_OVERRIDE_URL=https://static.cx-proto0.com/vilos-v2-qa/vex-4338-sub-default-font/web/vilos/player.html"

```
1. https://www.crunchyroll.com/ar/golden-kamuy/episode-1-wenkamuy-769171
2. Apply velocity override url in debug console above
3. Refresh page, and confirm that arabic subs are displayed properly (instead of square blocks)
```